### PR TITLE
Provide IE 11 support out of the box

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "array-findindex-polyfill": "^0.1.0",
     "ie-array-find-polyfill": "^1.1.0",
     "react": "^16.5.2",
-    "react-app-polyfill": "^0.2.2",
+    "react-app-polyfill": "^1.0.1",
     "react-dom": "^16.5.2",
     "react-scripts": "2.0.5"
   },
@@ -23,7 +23,8 @@
   "browserslist": [
     ">0.2%",
     "not dead",
-    "not ie <= 11",
+    "ie 11",
+    "not ie < 11",
     "not op_mini all"
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
-// Uncomment to add polyfills to run on IE (e.g. IE11)
-// import 'react-app-polyfill/ie9';
-// import 'ie-array-find-polyfill';
-// import 'array-findindex-polyfill';
+// Comment out following polyfills if you don't need IE11 support
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
 
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
- Add IE11 polyfills by default
- Update `react-app-polyfill` library to include latest IE11-compatible polyfill

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
